### PR TITLE
Fix accessing NULL variable as array in getSelectConditionStatementCo…

### DIFF
--- a/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
+++ b/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php
@@ -1707,7 +1707,7 @@ class BasicEntityPersister implements EntityPersister
                 }
 
                 $joinTableName = $this->quoteStrategy->getJoinTableName($association, $class, $this->platform);
-                $joinColumns   = $assoc['isOwningSide']
+                $joinColumns   = $association['isOwningSide']
                     ? $association['joinTable']['joinColumns']
                     : $association['joinTable']['inverseJoinColumns'];
 


### PR DESCRIPTION
…lumnSQL

$association was initialized, while $assoc can still be NULL. The actual 
data used later is $assocation too.